### PR TITLE
fixed elevation to fulfill material design guidelines when both actionbar and toolbar are present

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main;
 
+import android.animation.ObjectAnimator;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Intent;
@@ -191,10 +192,15 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
         }
     }
 
-    private void setTabLayoutElevation(int elevation){
+    private void setTabLayoutElevation(float newElevation){
+        if (mTabLayout == null) return;
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if (mTabLayout != null) {
-                mTabLayout.setElevation(elevation); //reset shadow
+            float oldElevation = mTabLayout.getElevation();
+            if (oldElevation != newElevation) {
+                ObjectAnimator.ofFloat(mTabLayout, "elevation", oldElevation, newElevation)
+                        .setDuration(1000L)
+                        .start();
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.design.widget.TabLayout;
@@ -62,6 +63,7 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
     private WPMainTabLayout mTabLayout;
     private WPMainTabAdapter mTabAdapter;
     private TextView mConnectionBar;
+    private int  mAppBarElevation;
 
     public static final String ARG_OPENED_FROM_PUSH = "opened_from_push";
 
@@ -126,6 +128,8 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
             }
         });
 
+        mAppBarElevation = getResources().getDimensionPixelSize(R.dimen.appbar_elevation);
+
         mViewPager.addOnPageChangeListener(new TabLayout.TabLayoutOnPageChangeListener(mTabLayout));
         mViewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
             @Override
@@ -133,10 +137,21 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
                 AppPrefs.setMainTabIndex(position);
 
                 switch (position) {
+                    case WPMainTabAdapter.TAB_MY_SITE:
+                        setTabLayoutElevation(mAppBarElevation);
+                        break;
+                    case WPMainTabAdapter.TAB_READER:
+                        setTabLayoutElevation(0);
+                    break;
+                    case WPMainTabAdapter.TAB_ME:
+                        setTabLayoutElevation(mAppBarElevation);
+                    break;
                     case WPMainTabAdapter.TAB_NOTIFS:
+                        setTabLayoutElevation(mAppBarElevation);
                         new UpdateLastSeenTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                         break;
                 }
+
                 trackLastVisibleTab(position, true);
             }
 
@@ -172,6 +187,14 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
                 }
             } else {
                 ActivityLauncher.showSignInForResult(this);
+            }
+        }
+    }
+
+    private void setTabLayoutElevation(int elevation){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (mTabLayout != null) {
+                mTabLayout.setElevation(elevation); //reset shadow
             }
         }
     }

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -13,8 +13,8 @@
     <dimen name="fab_margin_tablet">24dp</dimen>
 
     <!-- http://www.google.com/design/spec/what-is-material/elevation-shadows.html#elevation-shadows-shadows -->
-    <dimen name="appbar_elevation">8dp</dimen>
-    <dimen name="filter_subbar_elevation">4dp</dimen>
+    <dimen name="appbar_elevation">4dp</dimen>
+    <dimen name="filter_subbar_elevation">@dimen/appbar_elevation</dimen>
 
     <dimen name="card_elevation">2dp</dimen>
     <dimen name="card_elevation_pressed">8dp</dimen>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/3827

To test: just run on emulator/device running Android 5.0 or above. Check the video showing the behavior here https://www.dropbox.com/s/lhlbqwl6mumzabw/tablayoutshadow.mp4?dl=0  (the `elevation` for the Tabs is set to zero on Reader tab, and brought back to normal 4dp on the other tabs).

Needs review: @nbradbury @mattmiklic

@mattmiklic this solution works on devices with Lollipop or more. Previous Android OS versions don't pay attention to elevation as you surely have already seen elsewhere in the app.

@nbradbury Beware this is a PR on my own fork, as the original PR (https://github.com/wordpress-mobile/WordPress-Android/pull/3801) has not yet been merged. If you guys feel this suffices and addresses the design needs, I can merge this PR with my other branch and then let you merge the original PR on WP repo `develop` branch.
